### PR TITLE
Sortable Drag Performance: Fix drag item hang on dragLeave and dragEnter

### DIFF
--- a/js/ui/sortable.js
+++ b/js/ui/sortable.js
@@ -147,15 +147,11 @@ const Sortable = Draggable.inherit({
     dragEnter: function() {
         if(this === this._getTargetDraggable()) {
             this.option('toIndex', this.option('fromIndex'));
-        } else {
-            this.option('toIndex', -1);
         }
     },
 
     dragLeave: function() {
-        if(this === this._getTargetDraggable()) {
-            this.option('toIndex', -1);
-        } else {
+        if(this !== this._getTargetDraggable()) {
             this.option('toIndex', this.option('fromIndex'));
         }
     },


### PR DESCRIPTION
Happens in DropFeedbackMode Push. Code was wrong because animated row positions must not be reset on dragLeave because:

1. Consider typical drag-drop implementations on Windows:
  - Drag-Drop files in Windows Explorer
  - Drag-Drop text in a text editor
  - Drag-Drop diagrams in word
  - etc.
  You will never see that the source item that is being dragged is getting hidden once you drag the item out of the source window. In the same way, this should not be done here
2. The worst part is this:
  - Currently, immediately after collapsing all rows, they are expanded once again - inside the DragLeave event
  - First, all row positions are reset (collapsing the free-space row) and immediately afterwards, they are expanded again..

Collapsing the free space should only happen when

1. a row is dropped elsewhere
   AND
2. the item is meant to be removed from the source list (drag-move vs. drag-copy)

=> means neither in DragEnter nor in DragLeave

And this is what this commit is changing.

(Fixes T905423)